### PR TITLE
Adding working composer require command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install by using [Composer](https://getcomposer.org/). Go to the root directory 
 command line and execute this command:
 
 ```
-composer require joomlatools/joomlatools-framework-tags:1.*
+composer require joomlatools/framework-tags:1.*
 ```
 
 The component will be installed in the `vendor` folder of the root directory of your Joomla site. The composer installer 


### PR DESCRIPTION
Otherwise, I get this: 
[InvalidArgumentException]                                                                                                                                                                                                      
  Could not find a matching version of package joomlatools/joomlatools-framework-tags. Check the package spelling, your version constraint and that the package is available in a stability which matches your minimum-stability  
   (dev).